### PR TITLE
Fix testbot build failure due to 501 status

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ subprojects {
         mavenLocal()
 
         maven { url "https://jcenter.bintray.com/" }
-        maven { url "http://repo.maven.apache.org/maven2" }
+        maven { url "https://repo.maven.apache.org/maven2" }
         maven { url "https://jitpack.io/" }
     }
 }


### PR DESCRIPTION
Gradle fails because of this:
```
Could not HEAD 'http://repo.maven.apache.org/maven2/com/mewna/catnip/1.3.3/catnip-1.3.3.pom'. Received status code 501 from server: HTTPS Required
```

Not that the artifact exists there anyway.