### PR TITLE
Remove redundant volatiles/atomics, add dependency for netty epoll natives (vs just java code)

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile group: 'io.netty', name: 'netty-transport', version: '4.1.48.Final'
     compile group: 'io.netty', name: 'netty-codec-http', version: '4.1.48.Final'
-    compile group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.48.Final'
+    compile group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.48.Final', classifier: 'linux-x86_64'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.8.0-beta4'
     compileOnly group: 'org.jetbrains', name: 'annotations', version: '13.0'
 }

--- a/core/src/main/java/moe/kyokobot/koe/MediaConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/MediaConnection.java
@@ -45,7 +45,7 @@ public interface MediaConnection extends Closeable {
     @Nullable
     VoiceServerInfo getVoiceServerInfo();
 
-    ConnectionHandler getConnectionHandler();
+    ConnectionHandler<?> getConnectionHandler();
 
     void setAudioSender(@Nullable MediaFrameProvider sender);
 

--- a/core/src/main/java/moe/kyokobot/koe/codec/AbstractFramePoller.java
+++ b/core/src/main/java/moe/kyokobot/koe/codec/AbstractFramePoller.java
@@ -8,7 +8,7 @@ public abstract class AbstractFramePoller implements FramePoller {
     protected final MediaConnection connection;
     protected final ByteBufAllocator allocator;
     protected final EventLoopGroup eventLoop;
-    protected volatile boolean polling = false;
+    protected boolean polling = false;
 
     public AbstractFramePoller(MediaConnection connection) {
         this.connection = connection;

--- a/core/src/main/java/moe/kyokobot/koe/codec/netty/NettyFramePollerFactory.java
+++ b/core/src/main/java/moe/kyokobot/koe/codec/netty/NettyFramePollerFactory.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 public class NettyFramePollerFactory implements FramePollerFactory {
-    private Map<Codec, Function<MediaConnection, FramePoller>> codecMap;
+    private final Map<Codec, Function<MediaConnection, FramePoller>> codecMap;
 
     public NettyFramePollerFactory() {
         codecMap = new HashMap<>();

--- a/core/src/main/java/moe/kyokobot/koe/codec/netty/NettyOpusFramePoller.java
+++ b/core/src/main/java/moe/kyokobot/koe/codec/netty/NettyOpusFramePoller.java
@@ -3,11 +3,11 @@ package moe.kyokobot.koe.codec.netty;
 import moe.kyokobot.koe.MediaConnection;
 import moe.kyokobot.koe.codec.AbstractFramePoller;
 import moe.kyokobot.koe.codec.OpusCodec;
+import moe.kyokobot.koe.media.IntReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class NettyOpusFramePoller extends AbstractFramePoller {
     private static final Logger logger = LoggerFactory.getLogger(NettyOpusFramePoller.class);
@@ -24,7 +24,7 @@ public class NettyOpusFramePoller extends AbstractFramePoller {
     /**
      * Current frame timestamp.
      */
-    private AtomicInteger timestamp = new AtomicInteger();
+    private final IntReference timestamp = new IntReference();
 
     @Override
     public void start() {

--- a/core/src/main/java/moe/kyokobot/koe/crypto/XSalsa20Poly1305EncryptionMode.java
+++ b/core/src/main/java/moe/kyokobot/koe/crypto/XSalsa20Poly1305EncryptionMode.java
@@ -7,7 +7,7 @@ public class XSalsa20Poly1305EncryptionMode implements EncryptionMode {
     private final byte[] extendedNonce = new byte[24];
     private final byte[] m = new byte[984];
     private final byte[] c = new byte[984];
-    private TweetNaclFastInstanced nacl = new TweetNaclFastInstanced();
+    private final TweetNaclFastInstanced nacl = new TweetNaclFastInstanced();
 
     @Override
     @SuppressWarnings("Duplicates")

--- a/core/src/main/java/moe/kyokobot/koe/crypto/XSalsa20Poly1305LiteEncryptionMode.java
+++ b/core/src/main/java/moe/kyokobot/koe/crypto/XSalsa20Poly1305LiteEncryptionMode.java
@@ -3,14 +3,12 @@ package moe.kyokobot.koe.crypto;
 import io.netty.buffer.ByteBuf;
 import moe.kyokobot.koe.internal.crypto.TweetNaclFastInstanced;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 public class XSalsa20Poly1305LiteEncryptionMode implements EncryptionMode {
     private final byte[] extendedNonce = new byte[24];
     private final byte[] m = new byte[984];
     private final byte[] c = new byte[984];
-    private AtomicInteger seq = new AtomicInteger(0x80000000);
-    private TweetNaclFastInstanced nacl = new TweetNaclFastInstanced();
+    private final TweetNaclFastInstanced nacl = new TweetNaclFastInstanced();
+    private int seq = 0x80000000;
 
     @Override
     @SuppressWarnings("Duplicates")
@@ -24,7 +22,7 @@ public class XSalsa20Poly1305LiteEncryptionMode implements EncryptionMode {
             m[i + 32] = packet.readByte();
         }
 
-        int s = this.seq.getAndIncrement();
+        int s = this.seq++;
         extendedNonce[0] = (byte) (s & 0xff);
         extendedNonce[1] = (byte) ((s >> 8) & 0xff);
         extendedNonce[2] = (byte) ((s >> 16) & 0xff);

--- a/core/src/main/java/moe/kyokobot/koe/crypto/XSalsa20Poly1305SuffixEncryptionMode.java
+++ b/core/src/main/java/moe/kyokobot/koe/crypto/XSalsa20Poly1305SuffixEncryptionMode.java
@@ -9,7 +9,7 @@ public class XSalsa20Poly1305SuffixEncryptionMode implements EncryptionMode {
     private final byte[] extendedNonce = new byte[24];
     private final byte[] m = new byte[984];
     private final byte[] c = new byte[984];
-    private TweetNaclFastInstanced nacl = new TweetNaclFastInstanced();
+    private final TweetNaclFastInstanced nacl = new TweetNaclFastInstanced();
 
     @Override
     @SuppressWarnings("Duplicates")

--- a/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
@@ -46,8 +46,8 @@ public abstract class AbstractMediaGatewayConnection implements MediaGatewayConn
 
     protected EventExecutor eventExecutor;
     protected Channel channel;
-    private volatile boolean open;
-    private volatile boolean closed = false;
+    private boolean open;
+    private boolean closed = false;
 
     public AbstractMediaGatewayConnection(@NotNull MediaConnectionImpl connection,
                                           @NotNull VoiceServerInfo voiceServerInfo,
@@ -188,7 +188,7 @@ public abstract class AbstractMediaGatewayConnection implements MediaGatewayConn
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             if (!connectFuture.isDone()) {
                 connectFuture.completeExceptionally(cause);
             }

--- a/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
@@ -142,7 +142,7 @@ public abstract class AbstractMediaGatewayConnection implements MediaGatewayConn
         }
 
         @Override
-        public void channelInactive(ChannelHandlerContext ctx) {
+        public void channelInactive(@NotNull ChannelHandlerContext ctx) {
             close(1006, "Abnormal closure");
         }
 
@@ -200,7 +200,7 @@ public abstract class AbstractMediaGatewayConnection implements MediaGatewayConn
 
     private class WebSocketInitializer extends ChannelInitializer<SocketChannel> {
         @Override
-        protected void initChannel(SocketChannel ch) throws Exception {
+        protected void initChannel(SocketChannel ch) {
             var pipeline = ch.pipeline();
             var engine = sslContext.newEngine(ch.alloc());
             pipeline.addLast("ssl", new SslHandler(engine));

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV4Connection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV4Connection.java
@@ -32,7 +32,7 @@ public class MediaGatewayV4Connection extends AbstractMediaGatewayConnection {
     private SocketAddress address;
     private List<String> encryptionModes;
     private UUID rtcConnectionId;
-    private ScheduledFuture heartbeatFuture;
+    private ScheduledFuture<?> heartbeatFuture;
 
     public MediaGatewayV4Connection(MediaConnectionImpl connection, VoiceServerInfo voiceServerInfo) {
         super(connection, voiceServerInfo, 4);

--- a/core/src/main/java/moe/kyokobot/koe/internal/MediaConnectionImpl.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/MediaConnectionImpl.java
@@ -24,7 +24,7 @@ public class MediaConnectionImpl implements MediaConnection {
     private final EventDispatcher dispatcher;
 
     private MediaGatewayConnection gatewayConnection;
-    private ConnectionHandler connectionHandler;
+    private ConnectionHandler<?> connectionHandler;
     private VoiceServerInfo info;
     private Codec audioCodec;
     private Codec videoCodec;
@@ -113,7 +113,7 @@ public class MediaConnectionImpl implements MediaConnection {
     }
 
     @Override
-    public ConnectionHandler getConnectionHandler() {
+    public ConnectionHandler<?> getConnectionHandler() {
         return connectionHandler;
     }
 
@@ -247,7 +247,7 @@ public class MediaConnectionImpl implements MediaConnection {
         return dispatcher;
     }
 
-    public void setConnectionHandler(ConnectionHandler connectionHandler) {
+    public void setConnectionHandler(ConnectionHandler<?> connectionHandler) {
         this.connectionHandler = connectionHandler;
     }
 }

--- a/core/src/main/java/moe/kyokobot/koe/internal/crypto/Poly1305.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/crypto/Poly1305.java
@@ -26,10 +26,10 @@ package moe.kyokobot.koe.internal.crypto;
 
 @SuppressWarnings("Duplicates")
 public class Poly1305 {
-    private byte[] buffer;
-    private int[] r;
-    private int[] h;
-    private int[] pad;
+    private final byte[] buffer;
+    private final int[] r;
+    private final int[] h;
+    private final int[] pad;
     private int leftover;
     private int fin;
 

--- a/core/src/main/java/moe/kyokobot/koe/internal/crypto/TweetNaclFastInstanced.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/crypto/TweetNaclFastInstanced.java
@@ -452,7 +452,7 @@ public final class TweetNaclFastInstanced {
         cryptoStreamSalsa20Xor(c, m, d, sn, str);
     }
 
-    private Poly1305 poly1305 = new Poly1305();
+    private final Poly1305 poly1305 = new Poly1305();
 
     private void cryptoOnetimeAuth(
             byte[] out,

--- a/core/src/main/java/moe/kyokobot/koe/internal/handler/DiscordUDPConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/handler/DiscordUDPConnection.java
@@ -36,7 +36,7 @@ public class DiscordUDPConnection implements Closeable, ConnectionHandler<InetSo
     private DatagramChannel channel;
     private byte[] secretKey;
 
-    private volatile char seq;
+    private char seq;
 
     public DiscordUDPConnection(MediaConnection voiceConnection,
                                 SocketAddress serverAddress,

--- a/core/src/main/java/moe/kyokobot/koe/internal/handler/HolepunchHandler.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/handler/HolepunchHandler.java
@@ -11,14 +11,13 @@ import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class HolepunchHandler extends SimpleChannelInboundHandler<DatagramPacket> {
     private static final Logger logger = LoggerFactory.getLogger(HolepunchHandler.class);
 
     private final CompletableFuture<InetSocketAddress> future;
-    private final AtomicInteger tries = new AtomicInteger(0);
     private final int ssrc;
+    private int tries = 0;
     private DatagramPacket packet;
 
     public HolepunchHandler(CompletableFuture<InetSocketAddress> future, int ssrc) {
@@ -57,7 +56,7 @@ public class HolepunchHandler extends SimpleChannelInboundHandler<DatagramPacket
     public void holepunch(ChannelHandlerContext ctx) {
         if (future.isDone()) {
             return;
-        } else if (tries.getAndIncrement() > 10) {
+        } else if (tries++ > 10) {
             logger.debug("Discovery failed.");
             future.completeExceptionally(new SocketTimeoutException("Failed to discover external UDP address."));
             return;

--- a/core/src/main/java/moe/kyokobot/koe/internal/handler/HolepunchHandler.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/handler/HolepunchHandler.java
@@ -4,6 +4,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramPacket;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,7 +27,7 @@ public class HolepunchHandler extends SimpleChannelInboundHandler<DatagramPacket
     }
 
     @Override
-    public void channelActive(ChannelHandlerContext ctx) {
+    public void channelActive(@NotNull ChannelHandlerContext ctx) {
         holepunch(ctx);
     }
 

--- a/core/src/main/java/moe/kyokobot/koe/internal/handler/RTCPHandler.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/handler/RTCPHandler.java
@@ -7,7 +7,7 @@ import io.netty.channel.socket.DatagramPacket;
 public class RTCPHandler extends SimpleChannelInboundHandler<DatagramPacket> {
     // https://tools.ietf.org/html/rfc3550#section-6
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket packet) throws Exception {
+    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket packet) {
 
     }
 }

--- a/core/src/main/java/moe/kyokobot/koe/internal/json/JsonArray.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/json/JsonArray.java
@@ -41,7 +41,7 @@ public class JsonArray extends ArrayList<Object> {
 	/**
 	 * Creates an empty {@link JsonArray} from the given collection of objects.
 	 */
-	public JsonArray(Collection<? extends Object> collection) {
+	public JsonArray(Collection<?> collection) {
 		super(collection);
 	}
 
@@ -49,8 +49,7 @@ public class JsonArray extends ArrayList<Object> {
 	 * Creates a {@link JsonArray} from an array of contents.
 	 */
 	public static JsonArray from(Object... contents) {
-		JsonArray array = new JsonArray(Arrays.asList(contents));
-		return array;
+		return new JsonArray(Arrays.asList(contents));
 	}
 
 	/**

--- a/core/src/main/java/moe/kyokobot/koe/internal/json/JsonBuilder.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/json/JsonBuilder.java
@@ -18,7 +18,6 @@ package moe.kyokobot.koe.internal.json;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Stack;
 
 /**
  * Builds a {@link JsonObject} or {@link JsonArray}.

--- a/core/src/main/java/moe/kyokobot/koe/internal/json/JsonBuilder.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/json/JsonBuilder.java
@@ -15,6 +15,7 @@
  */
 package moe.kyokobot.koe.internal.json;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Stack;
@@ -26,8 +27,8 @@ import java.util.Stack;
  *            The type of JSON object to build.
  */
 public final class JsonBuilder<T> implements JsonSink<JsonBuilder<T>> {
-	private Stack<Object> json = new Stack<Object>();
-	private T root;
+	private final ArrayDeque<Object> json = new ArrayDeque<>();
+	private final T root;
 
 	JsonBuilder(T root) {
 		this.root = root;

--- a/core/src/main/java/moe/kyokobot/koe/internal/json/JsonLazyNumber.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/json/JsonLazyNumber.java
@@ -7,8 +7,8 @@ import java.math.BigDecimal;
  */
 @SuppressWarnings("serial")
 class JsonLazyNumber extends Number {
-	private String value;
-	private boolean isDouble;
+	private final String value;
+	private final boolean isDouble;
 
 	public JsonLazyNumber(String number, boolean isDoubleValue) {
 		this.value = number;

--- a/core/src/main/java/moe/kyokobot/koe/internal/json/JsonObject.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/json/JsonObject.java
@@ -33,7 +33,7 @@ public class JsonObject extends HashMap<String, Object> {
 	/**
 	 * Creates a {@link JsonObject} from an existing {@link Map}.
 	 */
-	public JsonObject(Map<? extends String, ? extends Object> map) {
+	public JsonObject(Map<? extends String, ?> map) {
 		super(map);
 	}
 

--- a/core/src/main/java/moe/kyokobot/koe/internal/json/JsonParser.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/json/JsonParser.java
@@ -38,8 +38,8 @@ public final class JsonParser {
     private Object value;
     private int token;
 
-    private JsonTokener tokener;
-    private boolean lazyNumbers;
+    private final JsonTokener tokener;
+    private final boolean lazyNumbers;
 
     /**
      * Returns a type-safe parser context for a {@link JsonObject}, {@link JsonArray} or "any" type from which you can

--- a/core/src/main/java/moe/kyokobot/koe/internal/json/JsonReader.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/json/JsonReader.java
@@ -11,13 +11,13 @@ import java.util.BitSet;
  * Streaming reader for JSON documents.
  */
 public final class JsonReader {
-	private JsonTokener tokener;
+	private final JsonTokener tokener;
 	private int token;
-	private BitSet states = new BitSet();
+	private final BitSet states = new BitSet();
 	private int stateIndex = 0;
 	private boolean inObject;
 	private boolean first = true;
-	private StringBuilder key = new StringBuilder();
+	private final StringBuilder key = new StringBuilder();
 
 	/**
 	 * The type of value that the {@link JsonReader} is positioned over.

--- a/core/src/main/java/moe/kyokobot/koe/internal/json/JsonTokener.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/json/JsonTokener.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Internal class for tokenizing JSON. Used by both {@link JsonParser} and {@link JsonReader}.
@@ -54,7 +55,7 @@ final class JsonTokener {
      */
     private static final class PseudoUtf8Reader extends Reader {
         private final InputStream buffered;
-        private byte[] buf = new byte[BUFFER_SIZE];
+        private final byte[] buf = new byte[BUFFER_SIZE];
 
         PseudoUtf8Reader(InputStream buffered) {
             this.buffered = buffered;
@@ -131,11 +132,11 @@ final class JsonTokener {
             } else if (sig[0] == 0xFF && sig[1] == 0xFE && sig[2] == 0x00 && sig[3] == 0x00) {
                 charset = Charset.forName("UTF-32LE");
             } else if (sig[0] == 0xFE && sig[1] == 0xFF) {
-                charset = Charset.forName("UTF-16BE");
+                charset = StandardCharsets.UTF_16BE;
                 buffered.reset();
                 buffered.skip(2);
             } else if (sig[0] == 0xFF && sig[1] == 0xFE) {
-                charset = Charset.forName("UTF-16LE");
+                charset = StandardCharsets.UTF_16LE;
                 buffered.reset();
                 buffered.skip(2);
             } else if (sig[0] == 0 && sig[1] == 0 && sig[2] == 0 && sig[3] != 0) {
@@ -145,10 +146,10 @@ final class JsonTokener {
                 charset = Charset.forName("UTF-32LE");
                 buffered.reset();
             } else if (sig[0] == 0 && sig[1] != 0 && sig[2] == 0 && sig[3] != 0) {
-                charset = Charset.forName("UTF-16BE");
+                charset = StandardCharsets.UTF_16BE;
                 buffered.reset();
             } else if (sig[0] != 0 && sig[1] == 0 && sig[2] != 0 && sig[3] == 0) {
-                charset = Charset.forName("UTF-16LE");
+                charset = StandardCharsets.UTF_16LE;
                 buffered.reset();
             } else {
                 buffered.reset();

--- a/core/src/main/java/moe/kyokobot/koe/internal/json/JsonWriter.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/json/JsonWriter.java
@@ -21,6 +21,7 @@ import java.io.PrintStream;
 import java.io.Writer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
 
@@ -55,7 +56,7 @@ public final class JsonWriter {
 	 * Allows for additional configuration of the {@link JsonWriter}.
 	 */
 	public static final class JsonWriterContext {
-		private String indent;
+		private final String indent;
 
 		private JsonWriterContext(String indent) {
 			this.indent = indent;
@@ -128,7 +129,7 @@ public final class JsonWriter {
 		//@formatter:on
 		public JsonAppendableWriter on(OutputStream out) {
 			return new JsonAppendableWriter(new OutputStreamWriter(out,
-					Charset.forName("UTF-8")), indent);
+					StandardCharsets.UTF_8), indent);
 		}
 
 	}

--- a/core/src/main/java/moe/kyokobot/koe/internal/json/JsonWriterBase.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/json/JsonWriterBase.java
@@ -46,7 +46,7 @@ class JsonWriterBase<SELF extends JsonWriterBase<SELF>> implements
 	private final StringBuilder buffer;
 	private final byte[] bb;
 	private int bo = 0;
-	private BitSet states = new BitSet();
+	private final BitSet states = new BitSet();
 	private int stateIndex = 0;
 	private boolean first = true;
 	private boolean inObject;
@@ -54,7 +54,7 @@ class JsonWriterBase<SELF extends JsonWriterBase<SELF>> implements
 	/**
 	 * Sequence to use for indenting.
 	 */
-	private String indentString;
+	private final String indentString;
 
 	/**
 	 * Current indent amount.

--- a/core/src/main/java/moe/kyokobot/koe/media/IntReference.java
+++ b/core/src/main/java/moe/kyokobot/koe/media/IntReference.java
@@ -1,0 +1,21 @@
+package moe.kyokobot.koe.media;
+
+/**
+ * Mutable reference to an int value. Provides no atomicity guarantees
+ * and should not be shared between threads without external synchronization.
+ */
+public class IntReference {
+    private int value;
+    
+    public int get() {
+        return value;
+    }
+    
+    public void set(int value) {
+        this.value = value;
+    }
+    
+    public void add(int amount) {
+        this.value += amount;
+    }
+}

--- a/core/src/main/java/moe/kyokobot/koe/media/MediaFrameProvider.java
+++ b/core/src/main/java/moe/kyokobot/koe/media/MediaFrameProvider.java
@@ -3,8 +3,6 @@ package moe.kyokobot.koe.media;
 import io.netty.buffer.ByteBuf;
 import moe.kyokobot.koe.codec.Codec;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 /**
  * Base interface for media frame providers. Note that Koe doesn't handle stuff such as speaking state, silent frames
  * or etc., these are implemented by codec-specific frame provider classes.
@@ -44,9 +42,10 @@ public interface MediaFrameProvider {
      *
      * @param codec     {@link Codec} type this handler was registered with.
      * @param buf       {@link ByteBuf} the buffer where the media data should be written to.
-     * @param timestamp {@link AtomicInteger} reference to current frame timestamp, which must be updated with
+     * @param timestamp {@link IntReference} reference to current frame timestamp, which must be updated with
      *                  timestamp of written frame.
      * @return If true, Koe will immediately attempt to poll a next frame, this is meant for video transmissions.
      */
-    boolean retrieve(Codec codec, ByteBuf buf, AtomicInteger timestamp);
+    boolean retrieve(Codec codec, ByteBuf buf, IntReference timestamp);
+    
 }

--- a/core/src/main/java/moe/kyokobot/koe/media/MediaFrameProvider.java
+++ b/core/src/main/java/moe/kyokobot/koe/media/MediaFrameProvider.java
@@ -27,12 +27,12 @@ public interface MediaFrameProvider {
 
     /**
      * @return If true, Koe will request media data for given {@link Codec} by
-     * calling {@link #retrieve(Codec, ByteBuf)} method.
+     * calling {@link #retrieve(Codec, ByteBuf, moe.kyokobot.koe.media.IntReference)} method.
      */
     boolean canSendFrame(Codec codec);
 
     /**
-     * If {@link #canSendFrame()} returns true, Koe will attempt to retrieve an media frame encoded with specified
+     * If {@link #canSendFrame(Codec)} returns true, Koe will attempt to retrieve an media frame encoded with specified
      * {@link Codec} type, by calling this method with target {@link ByteBuf} where the data should be written to.
      * Do not call {@link ByteBuf#release()} - memory management is already handled by Koe itself. In case if no
      * data gets written to the buffer, audio packet won't be sent.

--- a/ext-udpqueue/src/main/java/moe/kyokobot/koe/codec/udpqueue/QueueManagerPool.java
+++ b/ext-udpqueue/src/main/java/moe/kyokobot/koe/codec/udpqueue/QueueManagerPool.java
@@ -13,7 +13,7 @@ import static moe.kyokobot.koe.codec.udpqueue.UdpQueueFramePollerFactory.MAXIMUM
 public class QueueManagerPool {
     private final AtomicLong queueKeySeq;
     private final UdpQueueManager[] managers;
-    private volatile boolean closed;
+    private boolean closed;
 
     public QueueManagerPool(int size, int bufferDuration) {
         if (size <= 0) {

--- a/ext-udpqueue/src/main/java/moe/kyokobot/koe/codec/udpqueue/UdpQueueOpusFramePoller.java
+++ b/ext-udpqueue/src/main/java/moe/kyokobot/koe/codec/udpqueue/UdpQueueOpusFramePoller.java
@@ -4,19 +4,18 @@ import moe.kyokobot.koe.MediaConnection;
 import moe.kyokobot.koe.codec.AbstractFramePoller;
 import moe.kyokobot.koe.codec.OpusCodec;
 import moe.kyokobot.koe.internal.handler.DiscordUDPConnection;
+import moe.kyokobot.koe.media.IntReference;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class UdpQueueOpusFramePoller extends AbstractFramePoller {
-    private QueueManagerPool.UdpQueueWrapper manager;
-    private AtomicInteger timestamp;
+    private final QueueManagerPool.UdpQueueWrapper manager;
+    private final IntReference timestamp = new IntReference();
     private long lastFrame;
 
     public UdpQueueOpusFramePoller(QueueManagerPool.UdpQueueWrapper manager, MediaConnection connection) {
         super(connection);
-        this.timestamp = new AtomicInteger();
         this.manager = manager;
     }
 


### PR DESCRIPTION
- netty-transport-native-epoll is just the java part of the epoll implementation without the `linux-x86_64` classifier.
- netty only calls handlers from a single thread (as of 4.x, see https://netty.io/wiki/new-and-noteworthy-in-4.0.html#well-defined-thread-model), and ensures proper memory visibility between threads (5.x, see https://netty.io/wiki/new-and-noteworthy-in-5.0.html#even-more-flexible-thread-model).
  - I'm not entirely sure about HolepunchHandler, since it uses EventLoopGroup#schedule, which afaik has no guarantees about which thread will run the next holepunch attempt. The docs for ScheduledExecutorService also don't explicitly mention whether or not proper memory visibility will be enforced, but Executor enforces a happens-before on submit, so this is very likely to be safe. Worst case, it could be just marked volatile (or maybe an opaque / acquire-release VarHandle access).
- Also fixed a few warnings, marked fields that could be final as final, and some smaller code style changes.