### PR TITLE
Fix sporadic ArrayIndexOutOfBoundsException

### DIFF
--- a/core/src/main/java/moe/kyokobot/koe/crypto/EncryptionMode.java
+++ b/core/src/main/java/moe/kyokobot/koe/crypto/EncryptionMode.java
@@ -5,6 +5,8 @@ import io.netty.buffer.ByteBuf;
 import java.util.List;
 
 public interface EncryptionMode {
+    int ZERO_BYTES_LENGTH = 32; // For XSalsa20Poly1305
+
     boolean box(ByteBuf opus, int start, ByteBuf output, byte[] secretKey);
 
     String getName();

--- a/core/src/main/java/moe/kyokobot/koe/crypto/XSalsa20Poly1305EncryptionMode.java
+++ b/core/src/main/java/moe/kyokobot/koe/crypto/XSalsa20Poly1305EncryptionMode.java
@@ -5,8 +5,8 @@ import moe.kyokobot.koe.internal.crypto.TweetNaclFastInstanced;
 
 public class XSalsa20Poly1305EncryptionMode implements EncryptionMode {
     private final byte[] extendedNonce = new byte[24];
-    private final byte[] m = new byte[984];
-    private final byte[] c = new byte[984];
+    private final byte[] m = new byte[1276 + ZERO_BYTES_LENGTH];
+    private final byte[] c = new byte[1276 + ZERO_BYTES_LENGTH];
     private final TweetNaclFastInstanced nacl = new TweetNaclFastInstanced();
 
     @Override

--- a/core/src/main/java/moe/kyokobot/koe/crypto/XSalsa20Poly1305LiteEncryptionMode.java
+++ b/core/src/main/java/moe/kyokobot/koe/crypto/XSalsa20Poly1305LiteEncryptionMode.java
@@ -5,8 +5,8 @@ import moe.kyokobot.koe.internal.crypto.TweetNaclFastInstanced;
 
 public class XSalsa20Poly1305LiteEncryptionMode implements EncryptionMode {
     private final byte[] extendedNonce = new byte[24];
-    private final byte[] m = new byte[984];
-    private final byte[] c = new byte[984];
+    private final byte[] m = new byte[1276 + ZERO_BYTES_LENGTH];
+    private final byte[] c = new byte[1276 + ZERO_BYTES_LENGTH];
     private final TweetNaclFastInstanced nacl = new TweetNaclFastInstanced();
     private int seq = 0x80000000;
 

--- a/core/src/main/java/moe/kyokobot/koe/crypto/XSalsa20Poly1305SuffixEncryptionMode.java
+++ b/core/src/main/java/moe/kyokobot/koe/crypto/XSalsa20Poly1305SuffixEncryptionMode.java
@@ -7,8 +7,8 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class XSalsa20Poly1305SuffixEncryptionMode implements EncryptionMode {
     private final byte[] extendedNonce = new byte[24];
-    private final byte[] m = new byte[984];
-    private final byte[] c = new byte[984];
+    private final byte[] m = new byte[1276 + ZERO_BYTES_LENGTH];
+    private final byte[] c = new byte[1276 + ZERO_BYTES_LENGTH];
     private final TweetNaclFastInstanced nacl = new TweetNaclFastInstanced();
 
     @Override


### PR DESCRIPTION
An opus packet may have a length of up to 1275 bytes. There is additional padding for the box operation, of up to 32 bytes as defined here: https://github.com/InstantWebP2P/tweetnacl-java/blob/master/src/main/java/com/iwebpp/crypto/TweetNaclFast.java#L583

This has been tested and opus frames that would previously cause this error, no longer do.