### PR TITLE
implement new encryption modes

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,5 +3,6 @@ dependencies {
     implementation group: 'io.netty', name: 'netty-codec-http', version: '4.1.109.Final'
     implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.109.Final', classifier: 'linux-x86_64'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.8.0-beta4'
+    implementation group: 'com.google.crypto.tink', name: 'tink', version: '1.14.1'
     compileOnly group: 'org.jetbrains', name: 'annotations', version: '13.0'
 }

--- a/core/src/main/java/moe/kyokobot/koe/crypto/AEADAES256GCMRTPSizeEncryptionMode.java
+++ b/core/src/main/java/moe/kyokobot/koe/crypto/AEADAES256GCMRTPSizeEncryptionMode.java
@@ -1,0 +1,50 @@
+package moe.kyokobot.koe.crypto;
+
+import com.google.crypto.tink.aead.internal.InsecureNonceAesGcmJce;
+import io.netty.buffer.ByteBuf;
+
+import java.security.GeneralSecurityException;
+
+public class AEADAES256GCMRTPSizeEncryptionMode implements EncryptionMode {
+
+    private static final int NONCE_BYTES_LENGTH = 12;
+
+    private final byte[] extendedNonce = new byte[NONCE_BYTES_LENGTH];
+    private final byte[] associatedData = new byte[12];
+    private int seq = Math.abs(random.nextInt()) % 418 + 1;
+
+    @Override
+    @SuppressWarnings("Duplicates")
+    public boolean box(ByteBuf packet, int len, ByteBuf output, byte[] secretKey) {
+        var m = new byte[len];
+        packet.readBytes(m, 0, len);
+
+        var s = this.seq++;
+        extendedNonce[0] = (byte) (s & 0xff);
+        extendedNonce[1] = (byte) ((s >> 8) & 0xff);
+        extendedNonce[2] = (byte) ((s >> 16) & 0xff);
+        extendedNonce[3] = (byte) ((s >> 24) & 0xff);
+
+        // rtp header was already written to output
+        output.readBytes(associatedData);
+        output.resetReaderIndex();
+
+        byte[] c;
+        try {
+            var aesGcmJce = new InsecureNonceAesGcmJce(secretKey);
+
+            c = aesGcmJce.encrypt(extendedNonce, m, associatedData);
+        } catch (GeneralSecurityException e) {
+            return false;
+        }
+
+        output.writeBytes(c);
+        output.writeIntLE(s);
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return "aead_aes256_gcm_rtpsize";
+    }
+}

--- a/core/src/main/java/moe/kyokobot/koe/crypto/AEADXChaCha20Poly1305RTPSizeEncryptionMode.java
+++ b/core/src/main/java/moe/kyokobot/koe/crypto/AEADXChaCha20Poly1305RTPSizeEncryptionMode.java
@@ -1,0 +1,53 @@
+package moe.kyokobot.koe.crypto;
+
+import com.google.crypto.tink.aead.internal.InsecureNonceXChaCha20Poly1305;
+import io.netty.buffer.ByteBuf;
+
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+
+public class AEADXChaCha20Poly1305RTPSizeEncryptionMode implements EncryptionMode {
+
+    private static final int NONCE_BYTES_LENGTH = 24;
+
+    private final byte[] extendedNonce = new byte[NONCE_BYTES_LENGTH];
+    private final ByteBuffer c = ByteBuffer.allocate(1276 + TAG_BYTES_LENGTH + NONCE_BYTES_LENGTH);
+    private final byte[] associatedData = new byte[12];
+    private int seq = Math.abs(random.nextInt()) % 418 + 1;
+
+    @Override
+    @SuppressWarnings("Duplicates")
+    public boolean box(ByteBuf packet, int len, ByteBuf output, byte[] secretKey) {
+        var m = new byte[len];
+        packet.readBytes(m, 0, len);
+
+        var s = this.seq++;
+        extendedNonce[0] = (byte) (s & 0xff);
+        extendedNonce[1] = (byte) ((s >> 8) & 0xff);
+        extendedNonce[2] = (byte) ((s >> 16) & 0xff);
+        extendedNonce[3] = (byte) ((s >> 24) & 0xff);
+
+        // rtp header was already written to output
+        output.readBytes(associatedData);
+        output.resetReaderIndex();
+
+        c.clear();
+        c.limit(len + TAG_BYTES_LENGTH);
+        try {
+            var xChaCha20Poly1305 = new InsecureNonceXChaCha20Poly1305(secretKey);
+
+            xChaCha20Poly1305.encrypt(c, extendedNonce, m, associatedData);
+        } catch (GeneralSecurityException e) {
+            return false;
+        }
+
+        output.writeBytes(c.flip());
+        output.writeIntLE(s);
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return "aead_xchacha20_poly1305_rtpsize";
+    }
+}

--- a/core/src/main/java/moe/kyokobot/koe/crypto/DefaultEncryptionModes.java
+++ b/core/src/main/java/moe/kyokobot/koe/crypto/DefaultEncryptionModes.java
@@ -1,9 +1,15 @@
 package moe.kyokobot.koe.crypto;
 
+import java.security.Security;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
 class DefaultEncryptionModes {
+
+    private static final String AES_GCM_NO_PADDING = "AES_256/GCM/NOPADDING";
+
     private DefaultEncryptionModes() {
         //
     }
@@ -11,11 +17,20 @@ class DefaultEncryptionModes {
     static final Map<String, Supplier<EncryptionMode>> encryptionModes;
 
     static {
-        encryptionModes = Map.of( // sorted by priority
-                "xsalsa20_poly1305_lite", XSalsa20Poly1305LiteEncryptionMode::new,
-                "xsalsa20_poly1305_suffix", XSalsa20Poly1305SuffixEncryptionMode::new,
-                "xsalsa20_poly1305", XSalsa20Poly1305EncryptionMode::new,
-                "plain", PlainEncryptionMode::new // not supported by Discord anymore, implemented for testing.
-        );
+        // sorted by priority
+        var modes = new HashMap<String, Supplier<EncryptionMode>>();
+
+        // the jvm may not support this algorithm, so we need to check first if it is available
+        if (Security.getAlgorithms("Cipher").contains(AES_GCM_NO_PADDING)) {
+            modes.put("aead_aes256_gcm_rtpsize", AEADAES256GCMRTPSizeEncryptionMode::new); // recommended by Discord when available)
+        }
+
+        modes.put("aead_xchacha20_poly1305_rtpsize", AEADXChaCha20Poly1305RTPSizeEncryptionMode::new); // required by Discord
+        modes.put("xsalsa20_poly1305_lite", XSalsa20Poly1305LiteEncryptionMode::new); // deprecated and discontinued by Discord as of 18th of November 2024
+        modes.put("xsalsa20_poly1305_suffix", XSalsa20Poly1305SuffixEncryptionMode::new); // deprecated and discontinued by Discord as of 18th of November 2024
+        modes.put("xsalsa20_poly1305", XSalsa20Poly1305EncryptionMode::new); // deprecated and discontinued by Discord as of 18th of November 2024
+        modes.put("plain", PlainEncryptionMode::new); // not supported by Discord anymore, implemented for testing.
+
+        encryptionModes = Collections.unmodifiableMap(modes);
     }
 }

--- a/core/src/main/java/moe/kyokobot/koe/crypto/EncryptionMode.java
+++ b/core/src/main/java/moe/kyokobot/koe/crypto/EncryptionMode.java
@@ -2,10 +2,14 @@ package moe.kyokobot.koe.crypto;
 
 import io.netty.buffer.ByteBuf;
 
+import java.security.SecureRandom;
 import java.util.List;
 
 public interface EncryptionMode {
+    SecureRandom random = new SecureRandom();
+
     int ZERO_BYTES_LENGTH = 32; // For XSalsa20Poly1305
+    int TAG_BYTES_LENGTH = 16; // For AEAD
 
     boolean box(ByteBuf opus, int start, ByteBuf output, byte[] secretKey);
 


### PR DESCRIPTION
This pr implements the new `aead_aes256_gcm_rtpsize` & `aead_xchacha20_poly1305_rtpsize` encryption modes.

For this we rely on googles [tink](https://github.com/tink-crypto/tink-java) crypto library since java 11 has no built in support for `XChaCha20Poly1305` only `ChaCha20Poly1305`.
For convenience I also used tink for `AEAD AES256-GCM` which java has built-in support for


closes: https://github.com/KyokoBot/koe/issues/27


