### PR TITLE
feat: media valve

### DIFF
--- a/core/src/main/java/moe/kyokobot/koe/KoeOptions.java
+++ b/core/src/main/java/moe/kyokobot/koe/KoeOptions.java
@@ -18,14 +18,18 @@ public class KoeOptions {
     private final GatewayVersion gatewayVersion;
     private final FramePollerFactory framePollerFactory;
     private final boolean highPacketPriority;
+    private final boolean deafened;
 
-    public KoeOptions(@NotNull EventLoopGroup eventLoopGroup,
-                      @NotNull Class<? extends SocketChannel> socketChannelClass,
-                      @NotNull Class<? extends DatagramChannel> datagramChannelClass,
-                      @NotNull ByteBufAllocator byteBufAllocator,
-                      @NotNull GatewayVersion gatewayVersion,
-                      @NotNull FramePollerFactory framePollerFactory,
-                      boolean highPacketPriority) {
+    public KoeOptions(
+            @NotNull EventLoopGroup eventLoopGroup,
+            @NotNull Class<? extends SocketChannel> socketChannelClass,
+            @NotNull Class<? extends DatagramChannel> datagramChannelClass,
+            @NotNull ByteBufAllocator byteBufAllocator,
+            @NotNull GatewayVersion gatewayVersion,
+            @NotNull FramePollerFactory framePollerFactory,
+            boolean highPacketPriority,
+            boolean deafened
+    ) {
         this.eventLoopGroup = Objects.requireNonNull(eventLoopGroup);
         this.socketChannelClass = Objects.requireNonNull(socketChannelClass);
         this.datagramChannelClass = Objects.requireNonNull(datagramChannelClass);
@@ -33,6 +37,19 @@ public class KoeOptions {
         this.gatewayVersion = Objects.requireNonNull(gatewayVersion);
         this.framePollerFactory = Objects.requireNonNull(framePollerFactory);
         this.highPacketPriority = highPacketPriority;
+        this.deafened = deafened;
+    }
+
+    public KoeOptions(
+            @NotNull EventLoopGroup eventLoopGroup,
+            @NotNull Class<? extends SocketChannel> socketChannelClass,
+            @NotNull Class<? extends DatagramChannel> datagramChannelClass,
+            @NotNull ByteBufAllocator byteBufAllocator,
+            @NotNull GatewayVersion gatewayVersion,
+            @NotNull FramePollerFactory framePollerFactory,
+            boolean highPacketPriority
+    ) {
+        this(eventLoopGroup, socketChannelClass, datagramChannelClass, byteBufAllocator, gatewayVersion, framePollerFactory, highPacketPriority, false);
     }
 
     @NotNull
@@ -67,6 +84,10 @@ public class KoeOptions {
 
     public boolean isHighPacketPriority() {
         return highPacketPriority;
+    }
+
+    public boolean isDeafened() {
+        return deafened;
     }
 
     /**

--- a/core/src/main/java/moe/kyokobot/koe/KoeOptionsBuilder.java
+++ b/core/src/main/java/moe/kyokobot/koe/KoeOptionsBuilder.java
@@ -40,7 +40,7 @@ public class KoeOptionsBuilder {
                 : NioDatagramChannel.class;
 
         this.byteBufAllocator = new PooledByteBufAllocator();
-        this.gatewayVersion = GatewayVersion.V4;
+        this.gatewayVersion = GatewayVersion.V8;
         this.framePollerFactory = new NettyFramePollerFactory();
         this.highPacketPriority = true;
         this.deafened = false;

--- a/core/src/main/java/moe/kyokobot/koe/KoeOptionsBuilder.java
+++ b/core/src/main/java/moe/kyokobot/koe/KoeOptionsBuilder.java
@@ -24,6 +24,7 @@ public class KoeOptionsBuilder {
     private GatewayVersion gatewayVersion;
     private FramePollerFactory framePollerFactory;
     private boolean highPacketPriority;
+    private boolean deafened;
 
     KoeOptionsBuilder() {
         boolean epoll = Epoll.isAvailable();
@@ -42,6 +43,7 @@ public class KoeOptionsBuilder {
         this.gatewayVersion = GatewayVersion.V4;
         this.framePollerFactory = new NettyFramePollerFactory();
         this.highPacketPriority = true;
+        this.deafened = false;
     }
 
     public KoeOptionsBuilder setEventLoopGroup(EventLoopGroup eventLoopGroup) {
@@ -79,7 +81,11 @@ public class KoeOptionsBuilder {
         return this;
     }
 
+    public void setDeafened(boolean deafened) {
+        this.deafened = deafened;
+    }
+
     public KoeOptions create() {
-        return new KoeOptions(eventLoopGroup, socketChannelClass, datagramChannelClass, byteBufAllocator, gatewayVersion, framePollerFactory, highPacketPriority);
+        return new KoeOptions(eventLoopGroup, socketChannelClass, datagramChannelClass, byteBufAllocator, gatewayVersion, framePollerFactory, highPacketPriority, deafened);
     }
 }

--- a/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/AbstractMediaGatewayConnection.java
@@ -16,8 +16,8 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.concurrent.EventExecutor;
 import moe.kyokobot.koe.VoiceServerInfo;
-import moe.kyokobot.koe.internal.NettyBootstrapFactory;
 import moe.kyokobot.koe.internal.MediaConnectionImpl;
+import moe.kyokobot.koe.internal.NettyBootstrapFactory;
 import moe.kyokobot.koe.internal.json.JsonObject;
 import moe.kyokobot.koe.internal.json.JsonParser;
 import moe.kyokobot.koe.internal.util.NettyFutureWrapper;
@@ -66,6 +66,12 @@ public abstract class AbstractMediaGatewayConnection implements MediaGatewayConn
         } catch (SSLException | URISyntaxException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    @Nullable
+    @Override
+    public MediaValve getValve() {
+        return null;
     }
 
     @Override

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayConnection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayConnection.java
@@ -9,6 +9,12 @@ public interface MediaGatewayConnection {
 
     boolean isOpen();
 
+    /**
+     * @return The {@link MediaValve} used by this connection, or null if this gateway version does not support it.
+     */
+    @Nullable
+    MediaValve getValve();
+
     CompletableFuture<Void> start();
 
     void close(int code, @Nullable String reason);

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV4Connection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV4Connection.java
@@ -116,7 +116,7 @@ public class MediaGatewayV4Connection extends AbstractMediaGatewayConnection {
                 logger.debug("Resumed successfully");
                 break;
             }
-            case Op.CLIENT_CONNECT: {
+            case Op.VIDEO: {
                 var data = object.getObject("d");
                 var user = data.getString("user_id");
                 var audioSsrc = data.getInt("audio_ssrc", 0);
@@ -195,7 +195,7 @@ public class MediaGatewayV4Connection extends AbstractMediaGatewayConnection {
                         .add("data", udpInfo)
                         .combine(udpInfo));
 
-                sendInternalPayload(Op.CLIENT_CONNECT, new JsonObject()
+                sendInternalPayload(Op.VIDEO, new JsonObject()
                         .add("audio_ssrc", ssrc)
                         .add("video_ssrc", 0)
                         .add("rtx_ssrc", 0));

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV5Connection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV5Connection.java
@@ -38,6 +38,12 @@ public class MediaGatewayV5Connection extends AbstractMediaGatewayConnection {
         super(connection, voiceServerInfo, 5);
     }
 
+    @Nullable
+    @Override
+    public MediaValve getValve() {
+        return this.mediaValve;
+    }
+
     @Override
     protected void identify() {
         logger.debug("Identifying...");

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV5Connection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV5Connection.java
@@ -122,7 +122,7 @@ public class MediaGatewayV5Connection extends AbstractMediaGatewayConnection {
                 logger.debug("Resumed successfully");
                 break;
             }
-            case Op.CLIENT_CONNECT: {
+            case Op.VIDEO: {
                 mediaValve.handleEvent(object);
 
                 var data = object.getObject("d");
@@ -223,7 +223,7 @@ public class MediaGatewayV5Connection extends AbstractMediaGatewayConnection {
 
                 this.updateSpeaking(0);
 
-                sendInternalPayload(Op.CLIENT_CONNECT, new JsonObject()
+                sendInternalPayload(Op.VIDEO, new JsonObject()
                         .add("audio_ssrc", ssrc)
                         .add("video_ssrc", 0)
                         .add("rtx_ssrc", 0));

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV8Connection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV8Connection.java
@@ -85,7 +85,6 @@ public class MediaGatewayV8Connection extends AbstractMediaGatewayConnection {
                 break;
             }
             case Op.READY: {
-
                 resumable = true;
 
                 var data = object.getObject("d");
@@ -129,7 +128,7 @@ public class MediaGatewayV8Connection extends AbstractMediaGatewayConnection {
                 logger.debug("Resumed successfully");
                 break;
             }
-            case Op.CLIENT_CONNECT: {
+            case Op.VIDEO: {
                 mediaValve.handleEvent(object);
 
                 var data = object.getObject("d");
@@ -232,7 +231,7 @@ public class MediaGatewayV8Connection extends AbstractMediaGatewayConnection {
 
                 this.updateSpeaking(0);
 
-                sendInternalPayload(Op.CLIENT_CONNECT, new JsonObject()
+                sendInternalPayload(Op.VIDEO, new JsonObject()
                         .add("audio_ssrc", ssrc)
                         .add("video_ssrc", 0)
                         .add("rtx_ssrc", 0));

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV8Connection.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaGatewayV8Connection.java
@@ -39,6 +39,12 @@ public class MediaGatewayV8Connection extends AbstractMediaGatewayConnection {
         super(connection, voiceServerInfo, 8);
     }
 
+    @Nullable
+    @Override
+    public MediaValve getValve() {
+        return this.mediaValve;
+    }
+
     @Override
     protected void identify() {
         logger.debug("Identifying...");

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaValve.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaValve.java
@@ -36,6 +36,8 @@ public class MediaValve {
 
     /**
      * Set whether to deafen ourselves.
+     * <p>
+     * You must call {@link #sendToGateway()} after calling this method to have any effect.
      */
     public void setDeafen(boolean deafen) {
         this.deafen = deafen;
@@ -44,7 +46,7 @@ public class MediaValve {
     /**
      * Send a {@link Op#MEDIA_SINK_WANTS} payload to the gateway.
      */
-    public void sendToGateway() {
+    public synchronized void sendToGateway() {
         JsonObject d = new JsonObject();
 
         // disable all incoming audio streams.
@@ -61,7 +63,7 @@ public class MediaValve {
     /**
      * Handle a voice gateway message.
      */
-    public void handleEvent(JsonObject obj) {
+    synchronized void handleEvent(JsonObject obj) {
         int op = obj.getInt("op");
         if (op == Op.CLIENT_CONNECT) {
             JsonObject d = obj.getObject("d");

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaValve.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaValve.java
@@ -1,0 +1,97 @@
+package moe.kyokobot.koe.gateway;
+
+import moe.kyokobot.koe.internal.json.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tracks the media streams of each user connected to the Voice channel and disables their incoming packets.
+ */
+public class MediaValve {
+    private static final Logger LOG = LoggerFactory.getLogger(MediaValve.class.getName());
+
+    private final AbstractMediaGatewayConnection gatewayConnection;
+
+    /**
+     * A map of `user_id->streams[*].ssrc`
+     */
+    private final Map<String, int[]> unwantedStreams = new HashMap<>();
+
+    private boolean deafen = false;
+
+    public MediaValve(AbstractMediaGatewayConnection gatewayConnection) {
+        this.gatewayConnection = gatewayConnection;
+    }
+
+    /**
+     * Whether we're deafened, i.e., we are not receiving audio from any user.
+     */
+    public boolean isDeafened() {
+        return deafen;
+    }
+
+    /**
+     * Set whether to deafen ourselves.
+     */
+    public void setDeafen(boolean deafen) {
+        this.deafen = deafen;
+    }
+
+    /**
+     * Send a {@link Op#MEDIA_SINK_WANTS} payload to the gateway.
+     */
+    public void sendToGateway() {
+        JsonObject d = new JsonObject();
+
+        // disable all incoming audio streams.
+        d.add("any", deafen ? 0 : 100);
+
+        // add any unwanted streams.
+        for (int[] streams : unwantedStreams.values()) {
+            for (int ssrc : streams) d.add(Integer.toString(ssrc), 0);
+        }
+
+        this.gatewayConnection.sendInternalPayload(Op.MEDIA_SINK_WANTS, d);
+    }
+
+    /**
+     * Handle a voice gateway message.
+     */
+    public void handleEvent(JsonObject obj) {
+        int op = obj.getInt("op");
+        if (op == Op.CLIENT_CONNECT) {
+            JsonObject d = obj.getObject("d");
+            String userId = d.getString("user_id");
+
+            // if `video_ssrc` is 0, it indicates that the user is not showing their camera.
+            if (d.getInt("video_ssrc") == 0) {
+                this.removeUser(userId);
+                return;
+            }
+
+            // we can skip `audio_ssrc` since "any":0 covers audio.
+            // instead, all ssrcs listed in "streams".
+            int[] ssrcs = d.getArray("streams").stream()
+                    .filter(s -> s instanceof JsonObject)
+                    .mapToInt((stream) -> ((JsonObject) stream).getInt("ssrc"))
+                    .toArray();
+
+            LOG.debug("Received streams for user {}: {}", d, Arrays.toString(ssrcs));
+
+            this.unwantedStreams.put(userId, ssrcs);
+            this.sendToGateway();
+        } else if (op == Op.CLIENT_DISCONNECT) {
+            this.removeUser(obj.getObject("d").getString("user_id"));
+        }
+    }
+
+    void removeUser(String userId) {
+        LOG.debug("Removing streams for user {}", userId);
+        this.unwantedStreams.remove(userId);
+        this.sendToGateway();
+    }
+}

--- a/core/src/main/java/moe/kyokobot/koe/gateway/MediaValve.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/MediaValve.java
@@ -65,7 +65,7 @@ public class MediaValve {
      */
     synchronized void handleEvent(JsonObject obj) {
         int op = obj.getInt("op");
-        if (op == Op.CLIENT_CONNECT) {
+        if (op == Op.VIDEO) {
             JsonObject d = obj.getObject("d");
             String userId = d.getString("user_id");
 

--- a/core/src/main/java/moe/kyokobot/koe/gateway/Op.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/Op.java
@@ -20,5 +20,9 @@ public class Op {
     public static final int CLIENT_CONNECT = 12; // thx b1nzy
     public static final int CLIENT_DISCONNECT = 13;
     public static final int CODECS = 14;
-    public static final int VIDEO_SINK_WANTS = 15;
+    public static final int MEDIA_SINK_WANTS = 15;
+    /**
+     * @deprecated Use {@link #MEDIA_SINK_WANTS} instead.
+     */
+    public static final int VIDEO_SINK_WANTS = MEDIA_SINK_WANTS;
 }

--- a/core/src/main/java/moe/kyokobot/koe/gateway/Op.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/Op.java
@@ -16,13 +16,24 @@ public class Op {
     public static final int HELLO = 8;
     public static final int RESUMED = 9;
     // public static final int DUNNO = 10;
-    // public static final int DUNNO = 11;
-    public static final int CLIENT_CONNECT = 12; // thx b1nzy
+    public static final int CLIENT_CONNECT = 11;
+    public static final int VIDEO = 12;
     public static final int CLIENT_DISCONNECT = 13;
     public static final int CODECS = 14;
     public static final int MEDIA_SINK_WANTS = 15;
-    /**
-     * @deprecated Use {@link #MEDIA_SINK_WANTS} instead.
-     */
-    public static final int VIDEO_SINK_WANTS = MEDIA_SINK_WANTS;
+    public static final int VOICE_BACKEND_VERSION = 16;
+    public static final int CHANNEL_OPTIONS_UPDATE = 17;
+    public static final int CLIENT_FLAGS = 18;
+    public static final int SPEED_TEST = 19;
+    public static final int PLATFORM = 20;
+    public static final int SECURE_FRAMES_PREPARE_PROTOCOL_TRANSITION = 21;
+    public static final int SECURE_FRAMES_EXECUTE_TRANSITION = 22;
+    public static final int SECURE_FRAMES_READY_FOR_TRANSITION = 23;
+    public static final int SECURE_FRAMES_PREPARE_EPOCH = 24;
+    public static final int MLS_EXTERNAL_SENDER_PACKAGE = 25;
+    public static final int MLS_KEY_PACKAGE = 26;
+    public static final int MLS_PROPOSALS = 27;
+    public static final int MLS_COMMIT_WELCOME = 28;
+    public static final int MLS_PREPARE_COMMIT_TRANSITION = 29;
+    public static final int MLS_WELCOME = 30;
 }

--- a/core/src/main/java/moe/kyokobot/koe/gateway/Op.java
+++ b/core/src/main/java/moe/kyokobot/koe/gateway/Op.java
@@ -21,6 +21,10 @@ public class Op {
     public static final int CLIENT_DISCONNECT = 13;
     public static final int CODECS = 14;
     public static final int MEDIA_SINK_WANTS = 15;
+    /**
+     * @deprecated Use {@link #MEDIA_SINK_WANTS} instead.
+     */
+    public static final int VIDEO_SINK_WANTS = 15;
     public static final int VOICE_BACKEND_VERSION = 16;
     public static final int CHANNEL_OPTIONS_UPDATE = 17;
     public static final int CLIENT_FLAGS = 18;

--- a/core/src/main/java/moe/kyokobot/koe/internal/MediaConnectionImpl.java
+++ b/core/src/main/java/moe/kyokobot/koe/internal/MediaConnectionImpl.java
@@ -6,6 +6,7 @@ import moe.kyokobot.koe.codec.CodecType;
 import moe.kyokobot.koe.codec.FramePoller;
 import moe.kyokobot.koe.codec.OpusCodec;
 import moe.kyokobot.koe.gateway.MediaGatewayConnection;
+import moe.kyokobot.koe.gateway.MediaValve;
 import moe.kyokobot.koe.handler.ConnectionHandler;
 import moe.kyokobot.koe.media.MediaFrameProvider;
 import org.jetbrains.annotations.NotNull;
@@ -51,6 +52,12 @@ public class MediaConnectionImpl implements MediaConnection {
         return conn.start().thenAccept(nothing -> {
             MediaConnectionImpl.this.info = info;
             MediaConnectionImpl.this.gatewayConnection = conn;
+
+            MediaValve valve = conn.getValve();
+            if (valve != null && getOptions().isDeafened()) {
+                valve.setDeafen(true);
+                valve.sendToGateway();
+            }
         });
     }
 


### PR DESCRIPTION
Adds support for the `MEDIA_SINK_WANTS` opcode on gateway v5+

Currently, client (dis)connect opcodes are tracked to disable the video stream for connected users. Whether to mute all incoming audio can be set using `MediaValve#setDeafen` through `MediaGatewayConnection#getValve` or through `KoeOptions` for each `MediaConnection`.